### PR TITLE
Update to 4.12.1, configure flatpakexternal-data-checker

### DIFF
--- a/com.ktechpit.whatsie.yaml
+++ b/com.ktechpit.whatsie.yaml
@@ -1,9 +1,9 @@
 app-id: com.ktechpit.whatsie
 runtime: org.kde.Platform
-runtime-version: 5.15-21.08
+runtime-version: 5.15-22.08
 sdk: org.kde.Sdk
 base: io.qt.qtwebengine.BaseApp
-base-version: 5.15-21.08
+base-version: 5.15-22.08
 command: whatsie
 finish-args:
   - --device=all
@@ -21,15 +21,15 @@ finish-args:
   - --socket=fallback-x11
   - --socket=wayland
   - --socket=pulseaudio
-  
+
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=com.canonical.indicator.application
   - --talk-name=org.ayatana.indicator.application
-  
+
   - --system-talk-name=org.freedesktop.GeoClue2
   - --system-talk-name=org.freedesktop.UPower.*
-  
+
 cleanup-commands:
   - /app/cleanup-BaseApp.sh
 
@@ -48,4 +48,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/keshavbhatt/whatsie.git
-        tag: v4.10.2
+        tag: v4.12.1
+        commit: 085205eb692332ac694ca92c784fa027906aac3b
+        x-checker-data:
+          type: git
+          tag-pattern: ^(v[\d.]+)$


### PR DESCRIPTION
- Update to 4.12.1
- Configure [flatpakexternal-data-checker](https://github.com/flathub/flatpak-external-data-checker), which should allow for update PRs to be automatically created by flathubbot (is my understanding, at least :))