### PR TITLE
Add filesystem permissions for user convenience

### DIFF
--- a/com.ktechpit.whatsie.yaml
+++ b/com.ktechpit.whatsie.yaml
@@ -21,6 +21,14 @@ finish-args:
   - --system-talk-name=org.freedesktop.GeoClue2
   - --system-talk-name=org.freedesktop.UPower.*
 
+  # download and upload directories for convenience
+  - --filesystem=xdg-desktop
+  - --filesystem=xdg-documents
+  - --filesystem=xdg-download
+  - --filesystem=xdg-music
+  - --filesystem=xdg-pictures
+  - --filesystem=xdg-videos
+
 cleanup-commands:
   - /app/cleanup-BaseApp.sh
 


### PR DESCRIPTION
Added filesystem permissions for various user directories. They were dropped recently by mistake. Users are complaining about missing download and lost the ability to attach documents, files, photos in chat.

**see:** 
- https://github.com/keshavbhatt/whatsie/issues/297
- https://github.com/keshavbhatt/whatsie/issues/296
